### PR TITLE
Expose the UA's os as a property on the results

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,14 @@ if (bowser.msie && bowser.version <= 6) {
 
 For all detected browsers the browser version is set in the `version` field.
 
-## Flags set for detected mobile Operating Systems
+## Flags set for detected Operating Systems
 
+  * `mac`
+  *  Windows other than Windows Phone as `windows`
+  *  Windows Phone as `windowsphone`
+  * `linux` for Linux other than `android`, `chromeos`, `webos`, `tizen`, and `sailfish`
+  * `chromeos`
   * `android`
-  * Windows Phone as `windowsphone`
   * `ios` (`iphone`/`ipad`/`ipod`)
   * `blackberry`
   * `firefoxos`

--- a/src/bowser.js
+++ b/src/bowser.js
@@ -24,7 +24,15 @@
     var iosdevice = getFirstMatch(/(ipod|iphone|ipad)/i).toLowerCase()
       , likeAndroid = /like android/i.test(ua)
       , android = !likeAndroid && /android/i.test(ua)
-      , chromeBook = /CrOS/.test(ua)
+      , chromeos = /CrOS/.test(ua)
+      , silk = /silk/i.test(ua)
+      , sailfish = /sailfish/i.test(ua)
+      , tizen = /tizen/i.test(ua)
+      , webos = /(web|hpw)os/i.test(ua)
+      , windowsphone = /windows phone/i.test(ua)
+      , windows = !windowsphone && /windows/i.test(ua)
+      , mac = !iosdevice && !silk && /macintosh/i.test(ua)
+      , linux = !android && !sailfish && !tizen && !webos && /linux/i.test(ua)
       , edgeVersion = getFirstMatch(/edge\/(\d+(\.\d+)?)/i)
       , versionIdentifier = getFirstMatch(/version\/(\d+(\.\d+)?)/i)
       , tablet = /tablet/i.test(ua)
@@ -45,7 +53,7 @@
       , version: versionIdentifier || getFirstMatch(/(?:yabrowser)[\s\/](\d+(\.\d+)?)/i)
       }
     }
-    else if (/windows phone/i.test(ua)) {
+    else if (windowsphone) {
       result = {
         name: 'Windows Phone'
       , windowsphone: t
@@ -65,9 +73,10 @@
       , msie: t
       , version: getFirstMatch(/(?:msie |rv:)(\d+(\.\d+)?)/i)
       }
-    } else if (chromeBook) {
+    } else if (chromeos) {
       result = {
         name: 'Chrome'
+      , chromeos: t
       , chromeBook: t
       , chrome: t
       , version: getFirstMatch(/(?:chrome|crios|crmo)\/(\d+(\.\d+)?)/i)
@@ -95,7 +104,7 @@
         result.version = versionIdentifier
       }
     }
-    else if (/sailfish/i.test(ua)) {
+    else if (sailfish) {
       result = {
         name: 'Sailfish'
       , sailfish: t
@@ -119,7 +128,7 @@
         result.firefoxos = t
       }
     }
-    else if (/silk/i.test(ua)) {
+    else if (silk) {
       result =  {
         name: 'Amazon Silk'
       , silk: t
@@ -146,7 +155,7 @@
       , version: versionIdentifier || getFirstMatch(/blackberry[\d]+\/(\d+(\.\d+)?)/i)
       }
     }
-    else if (/(web|hpw)os/i.test(ua)) {
+    else if (webos) {
       result = {
         name: 'WebOS'
       , webos: t
@@ -161,7 +170,7 @@
       , version: getFirstMatch(/dolfin\/(\d+(\.\d+)?)/i)
       };
     }
-    else if (/tizen/i.test(ua)) {
+    else if (tizen) {
       result = {
         name: 'Tizen'
       , tizen: t
@@ -201,6 +210,12 @@
     } else if (iosdevice) {
       result[iosdevice] = t
       result.ios = t
+    } else if (windows) {
+      result.windows = t
+    } else if (mac) {
+      result.mac = t
+    } else if (linux) {
+      result.linux = t
     }
 
     // OS version extraction

--- a/src/useragents.js
+++ b/src/useragents.js
@@ -75,12 +75,14 @@ module.exports.useragents = {
     , 'Mozilla/5.0 (Windows NT 6.2; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.17 Safari/537.36': {
         chrome: true
       , version: '30.0'
+      , windows: true
       , webkit: true
       , a: true
       }
     , 'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.62 Safari/537.36': {
         chrome: true
       , version: '29.0'
+      , windows: true
       , webkit: true
       , a: true
       }
@@ -88,30 +90,35 @@ module.exports.useragents = {
         chrome: true
       , chromeBook: true
       , version: '29.0'
+      , chromeos: true
       , webkit: true
       , a: true
       }
     , 'Mozilla/5.0 (Windows NT 6.2; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.2 Safari/537.36': {
         chrome: true
       , version: '29.0'
+      , windows: true
       , webkit: true
       , a: true
       }
     , 'Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1468.0 Safari/537.36': {
         chrome: true
       , version: '28.0'
+      , windows: true
       , webkit: true
       , a: true
       }
     , 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_6_7) AppleWebKit/534.24 (KHTML, like Gecko) Chrome/11.0.696.57 Safari/534.24': {
         chrome: true
       , version: '11.0'
+      , mac: true
       , webkit: true
       , c: true
       }
     , 'Mozilla/5.0 (X11; U; Linux i686; en-US) AppleWebKit/534.3 (KHTML, like Gecko) Chrome/6.0.462.0 Safari/534.3': {
         chrome: true
       , version: '6.0'
+      , linux: true
       , webkit: true
       , c: true
       }
@@ -177,6 +184,7 @@ module.exports.useragents = {
       }
     , 'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.52 Safari/537.36 OPR/15.0.1147.100': {
         opera: true
+      , windows: true
       , webkit: true
       , version: '15.0'
       , a: true
@@ -200,56 +208,67 @@ module.exports.useragents = {
     , 'Opera/9.80 (Windows NT 6.0) Presto/2.12.388 Version/12.14': {
         opera: true
       , version: '12.14'
+      , windows: true
       , a: true
       }
     , 'Mozilla/5.0 (Windows NT 6.0; rv:2.0) Gecko/20100101 Firefox/4.0 Opera 12.14': {
         opera: true
       , version: '12.14'
+      , windows: true
       , a: true
       }
     , 'Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.0) Opera 12.14': {
         opera: true
       , version: '12.14'
+      , windows: true
       , a: true
       }
     , 'Opera/12.80 (Windows NT 5.1; U; en) Presto/2.10.289 Version/12.02': {
         opera: true
       , version: '12.02'
+      , windows: true
       , a: true
       }
     , 'Opera/9.80 (X11; Linux i686; U; es-ES) Presto/2.8.131 Version/11.11': {
         opera: true
       , version: '11.11'
+      , linux: true
       , a: true
       }
     , 'Opera/9.80 (Macintosh; Intel Mac OS X 10.6.7; U; en) Presto/2.7.62 Version/11.01': {
         opera: true
       , version: '11.01'
+      , mac: true
       , a: true
       }
     , 'Opera/9.80 (Windows NT 5.2; U; zh-cn) Presto/2.6.30 Version/10.63': {
         opera: true
       , version: '10.63'
+      , windows: true
       , a: true
       }
     , 'Opera/9.80 (X11; Linux i686; U; it) Presto/2.5.24 Version/10.54': {
         opera: true
       , version: '10.54'
+      , linux: true
       , a: true
       }
     , 'Opera/9.70 (Linux ppc64 ; U; en) Presto/2.2.1': {
         opera: true
       , version: '9.70'
+      , linux: true
       , c: true
       }
     , 'Opera/9.63 (X11; Linux i686)': {
         opera: true
       , version: '9.63'
+      , linux: true
       , c: true
       }
     , 'Mozilla/5.0 (X11; Linux i686; U; en) Opera 8.52': {
         opera: true
       , version: '8.52'
+      , linux: true
       , c: true
       }
     }
@@ -258,6 +277,7 @@ module.exports.useragents = {
             yandexbrowser: true
             , webkit: true
             , version: '15.4'
+            , mac: true
             , a: true
         },
         'Mozilla/5.0 (Linux; Android 5.1.1; Nexus 5 Build/LMY48B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.118 YaBrowser/15.4.2272.3608.00 Mobile Safari/537.36': {
@@ -274,42 +294,49 @@ module.exports.useragents = {
       'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_6_8) AppleWebKit/537.13+ (KHTML, like Gecko) Version/5.1.7 Safari/534.57.2': {
         safari: true
       , version: '5.1'
+      , mac: true
       , webkit: true
       , c: true
       }
     , 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_7; en-us) AppleWebKit/533.21.1 (KHTML, like Gecko) Version/5.0.5 Safari/533.21.1': {
         safari: true
       , version: '5.0'
+      , mac: true
       , webkit: true
       , c: true
       }
     , 'Mozilla/5.0 (Windows; U; Windows NT 5.1; ru-RU) AppleWebKit/533.18.1 (KHTML, like Gecko) Version/5.0.2 Safari/533.18.5': {
         safari: true
       , version: '5.0'
+      , windows: true
       , webkit: true
       , c: true
       }
     , 'Mozilla/5.0 (X11; U; Linux x86_64; en-us) AppleWebKit/531.2+ (KHTML, like Gecko) Version/5.0 Safari/531.2+': {
         safari: true
       , version: '5.0'
+      , linux: true
       , webkit: true
       , c: true
       }
     , 'Mozilla/5.0 (Windows; U; Windows NT 5.0; en-en) AppleWebKit/533.16 (KHTML, like Gecko) Version/4.1 Safari/533.16': {
         safari: true
       , version: '4.1'
+      , windows: true
       , webkit: true
       , c: true
       }
     , 'Mozilla/5.0 (Macintosh; U; PPC Mac OS X 10_6_1; en_GB, en_US) AppleWebKit/531.21.10 (KHTML, like Gecko) Version/4.0.4 Safari/531.21.10': {
         safari: true
       , version: '4.0'
+      , mac: true
       , webkit: true
       , c: true
       }
     , 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_7; de-de) AppleWebKit/525.28.3 (KHTML, like Gecko) Version/3.2.3 Safari/525.28.3': {
         safari: true
       , version: '3.2'
+      , mac: true
       , webkit: true
       , c: true
       }
@@ -318,61 +345,73 @@ module.exports.useragents = {
       'Mozilla/5.0 (Windows NT 6.3; Win64; x64; Trident/7.0; MAARJS; rv:11.0) like Gecko': {
         msie: true
       , version: '11.0'
+      , windows: true
       , a: true
       }
     , 'Mozilla/5.0 (Windows NT 6.3; WOW64; Trident/7.0; Touch; rv:11.0) like Gecko': {
         msie: true
       , version: '11.0'
+      , windows: true
       , a: true
       }
     , 'Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0; ARM; Touch; WPDesktop)': {
         msie: true
       , version: '10.0'
+      , windows: true
       , a: true
       }
     , 'Mozilla/5.0 (Windows NT 6.3; WOW64; Trident/7.0; .NET4.0E; .NET4.0C; Media Center PC 6.0; rv:11.0) like Gecko': {
         msie: true
       , version: '11.0'
+      , windows: true
       , a: true
       }
     , 'Mozilla/5.0 (compatible; MSIE 10.6; Windows NT 6.1; Trident/5.0; InfoPath.2; SLCC1; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729; .NET CLR 2.0.50727) 3gpp-gba UNTRUSTED/1.0': {
         msie: true
       , version: '10.6'
+      , windows: true
       , a: true
       }
     , 'Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; Trident/4.0; InfoPath.2; SV1; .NET CLR 2.0.50727; WOW64)': {
         msie: true
       , version: '10.0'
+      , windows: true
       , a: true
       }
     , 'Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Win64; x64; Trident/5.0; .NET CLR 3.5.30729; .NET CLR 3.0.30729; .NET CLR 2.0.50727; Media Center PC 6.0)': {
         msie: true
       , version: '9.0'
+      , windows: true
       , c: true
       }
     , 'Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.1; Trident/5.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; .NET4.0C)': {
         msie: true
       , version: '8.0'
+      , windows: true
       , c: true
       }
     , 'Mozilla/4.0 (compatible; MSIE 7.0b; Windows NT 5.1; .NET CLR 1.1.4322; InfoPath.1; .NET CLR 2.0.50727)': {
         msie: true
       , version: '7.0'
+      , windows: true
       , c: true
       }
     , 'Mozilla/4.0 (compatible; MSIE 6.1; Windows XP; .NET CLR 1.1.4322; .NET CLR 2.0.50727)': {
         msie: true
       , version: '6.1'
+      , windows: true
       , c: true
       }
     , 'Mozilla/4.0 (Compatible; Windows NT 5.1; MSIE 6.0) (compatible; MSIE 6.0; Windows NT 5.1; .NET CLR 1.1.4322; .NET CLR 2.0.50727)': {
         msie: true
       , version: '6.0'
+      , windows: true
       , c: true
       }
     , 'Mozilla/4.0 (compatible; MSIE 5.01; Windows NT)': {
         msie: true
       , version: '5.01'
+      , windows: true
       , c: true
       }
     }
@@ -380,6 +419,7 @@ module.exports.useragents = {
       'Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.71 Safari/537.36 Edge/12.0': {
         msedge: true
       , version: '12.0'
+      , windows: true
       , a: true
       }
     }
@@ -428,78 +468,91 @@ module.exports.useragents = {
         gecko: true
       , firefox: true
       , version: '25.0'
+      , windows: true
       , a: true
       }
     , 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.8; rv:24.0) Gecko/20100101 Firefox/24.0': {
         gecko: true
       , firefox: true
       , version: '24.0'
+      , mac: true
       , a: true
       }
     , 'Mozilla/5.0 (X11; Linux i686; rv:21.0) Gecko/20100101 Firefox/21.0': {
         gecko: true
       , firefox: true
       , version: '21.0'
+      , linux: true
       , a: true
       }
     , 'Mozilla/5.0 (X11; Linux x86_64; rv:17.0) Gecko/20121202 Firefox/17.0 Iceweasel/17.0.1': {
         gecko: true
       , firefox: true
       , version: '17.0'
+      , linux: true
       , c: true
       }
     , 'Mozilla/5.0 (X11; Linux x86_64; rv:15.0) Gecko/20120724 Debian Iceweasel/15.0': {
         gecko: true
       , firefox: true
       , version: '15.0'
+      , linux: true
       , c: true
       }
     , 'Mozilla/5.0 (Windows NT 6.2; WOW64; rv:15.0) Gecko/20120910144328 Firefox/15.0.2': {
         gecko: true
       , firefox: true
       , version: '15.0'
+      , windows: true
       , c: true
       }
     , 'Mozilla/5.0 (Windows; U; Windows NT 6.1; WOW64; en-US; rv:2.0.4) Gecko/20120718 AskTbAVR-IDW/3.12.5.17700 Firefox/14.0.1': {
         gecko: true
       , firefox: true
       , version: '14.0'
+      , windows: true
       , c: true
       }
     , 'Mozilla/5.0 (Windows NT 5.1; rv:6.0) Gecko/20100101 Firefox/6.0 FirePHP/0.6': {
         gecko: true
       , firefox: true
       , version: '6.0'
+      , windows: true
       , c: true
       }
     , 'Mozilla/5.0 (X11; Linux x86_64; rv:2.2a1pre) Gecko/20100101 Firefox/4.2a1pre': {
         gecko: true
       , firefox: true
       , version: '4.2'
+      , linux: true
       , c: true
       }
     , 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.6; rv:2.0) Gecko/20100101 Firefox/4.0': {
         gecko: true
       , firefox: true
       , version: '4.0'
+      , mac: true
       , c: true
       }
     , 'Mozilla/5.0 (Windows; U; Windows NT 6.1; en-US; rv:1.9.2b1) Gecko/20091014 Firefox/3.6b1 GTB5': {
         gecko: true
       , firefox: true
       , version: '3.6'
+      , windows: true
       , c: true
       }
     , 'Mozilla/5.0 (Windows; U; Windows NT 6.0; de; rv:1.9.0.15) Gecko/2009101601 Firefox 2.1 (.NET CLR 3.5.30729)': {
         gecko: true
       , firefox: true
       , version: '2.1'
+      , windows: true
       , c: true
       }
     , 'Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.8.0.7) Gecko/20061014 Firefox/1.5.0.7': {
         gecko: true
       , firefox: true
       , version: '1.5'
+      , linux: true
       , c: true
       }
     }
@@ -508,18 +561,21 @@ module.exports.useragents = {
         gecko: true
       , seamonkey: true
       , version: '2.7'
+      , windows: true
       , x: true
       }
     , 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.5; rv:10.0.1) Gecko/20100101 Firefox/10.0.1 SeaMonkey/2.7.1': {
         gecko: true
       , seamonkey: true
       , version: '2.7'
+      , mac: true
       , x: true
       }
     , 'Mozilla/5.0 (X11; Linux i686; rv:10.0.1) Gecko/20100101 Firefox/10.0.1 SeaMonkey/2.7.1': {
         gecko: true
       , seamonkey: true
       , version: '2.7'
+      , linux: true
       , x: true
       }
     }
@@ -961,6 +1017,7 @@ module.exports.useragents = {
         phantom: true
       , webkit: true
       , version: '1.5'
+      , mac: true
       , x: true
       }
     }


### PR DESCRIPTION
Resolves #98

This adds a property for the browser's operating system to the results object. A couple notes:

* I changed `chromeBook` to `chromeos` as `CrOS` will match things like chrome*boxes* in addition to chromebooks and I think it makes sense in this case to reflect the OS rather than the hardware (the only other place this is done is with iPad/iPod/iPhone). Kept `chromeBook` for backwards compat.

* Use `linux` for traditional desktop linux systems and leaves the specific vendor names like `android`, `chromeos`, `sailfish`, etc. for those projects that are just built on the kernel and don't use traditional gtk, etc.

* Use `windows` for windows UAs that aren't windows phone

* Hoisted up a bunch of the regexes. Getting the feeling that the creation of the results object could be broken up into stages, where each stage adds an appropriate category of property (browser name, os, os version, etc). They're a bit intertwined at the moment.

Appreciate your feedback. Thanks for the awesome module!