### PR TITLE
Fix for 'iPad' showing as the browser on iPad.

### DIFF
--- a/src/bowser.js
+++ b/src/bowser.js
@@ -88,7 +88,8 @@
     }
     else if (iosdevice) {
       result = {
-        name : iosdevice == 'iphone' ? 'iPhone' : iosdevice == 'ipad' ? 'iPad' : 'iPod'
+        name : 'Safari'
+      , safari: t
       }
       // WTF: version is not part of user agent in web apps
       if (versionIdentifier) {
@@ -234,6 +235,7 @@
     }
 
     // Graded Browser Support
+    // Graded Browser Support
     // http://developer.yahoo.com/yui/articles/gbs
     if (result.msedge ||
         (result.msie && result.version >= 10) ||
@@ -250,7 +252,7 @@
     else if ((result.msie && result.version < 10) ||
         (result.chrome && result.version < 20) ||
         (result.firefox && result.version < 20.0) ||
-        (result.safari && result.version < 6) ||
+        (result.safari && result.version < 6 && !result.ios) ||
         (result.opera && result.version < 10.0) ||
         (result.ios && result.osversion && result.osversion.split(".")[0] < 6)
         ) {

--- a/src/useragents.js
+++ b/src/useragents.js
@@ -531,6 +531,8 @@ module.exports.useragents = {
       , mobile: true
       , webkit: true
       , a: true
+      , name: 'Safari'
+      , safari: true
       }
     , 'Mozilla/5.0 (iPhone Simulator; U; CPU iPhone OS 4_3_2 like Mac OS X; en-us) AppleWebKit/533.17.9 (KHTML, like Gecko) Version/5.0.2 Mobile/8H7 Safari/6533.18.5': {
         ios: true
@@ -540,6 +542,8 @@ module.exports.useragents = {
       , mobile: true
       , webkit: true
       , c: true
+      , name: 'Safari'
+      , safari: true
       }
     , 'Mozilla/5.0 (iPhone; U; CPU like Mac OS X; en) AppleWebKit/420+ (KHTML, like Gecko) Version/3.0 Mobile/1A543a Safari/419.3': {
         ios: true
@@ -548,6 +552,8 @@ module.exports.useragents = {
       , mobile: true
       , webkit: true
       , x: true
+      , name: 'Safari'
+      , safari: true
       }
     , 'Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_1 like Mac OS X; en-us) AppleWebKit/532.9 (KHTML, like Gecko) Version/4.0.5 Mobile/8B5097d Safari/6531.22.7': {
         ios: true
@@ -557,6 +563,8 @@ module.exports.useragents = {
       , mobile: true
       , webkit: true
       , c: true
+      , name: 'Safari'
+      , safari: true
       }
     , 'Mozilla/5.0 (Macintosh; U; PPC Mac OS X 10_5_2; en-gb) AppleWebKit/526+ (KHTML, like Gecko) Version/3.1 iPhone': {
         ios: true
@@ -565,58 +573,65 @@ module.exports.useragents = {
       , mobile: true
       , webkit: true
       , x: true
+      , name: 'Safari'
+      , safari: true
       }
     }
   , iPad: {
       'Mozilla/5.0 (iPad; CPU OS 7_0_4 like Mac OS X) AppleWebKit/537.51.1 (KHTML, like Gecko) Version/7.0 Mobile/11B554a Safari/9537.53': {
         ios: true
       , osversion: '7.0.4'
-      , name: 'iPad'
       , version: '7.0'
       , ipad: true
       , tablet: true
       , webkit: true
       , a: true
+      , name: 'Safari'
+      , safari: true
       }
     , 'Mozilla/5.0 (iPad; CPU OS 6_0 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Version/6.0 Mobile/10A5355d Safari/8536.25': {
         ios: true
       , osversion: '6.0'
-      , name: 'iPad'
+      , name: 'Safari'
       , version: '6.0'
       , ipad: true
       , tablet: true
       , webkit: true
       , a: true
+      , safari: true
       }
     , 'Mozilla/5.0 (iPad; CPU OS 5_1 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko ) Version/5.1 Mobile/9B176 Safari/7534.48.3': {
         ios: true
       , osversion: '5.1'
-      , name: 'iPad'
+      , name: 'Safari'
       , version: '5.1'
       , ipad: true
       , tablet: true
       , webkit: true
       , c: true
+      , safari: true
       }
     , 'Mozilla/5.0 (iPad; U; CPU OS 4_3_2 like Mac OS X; en-us) AppleWebKit/533.17.9 (KHTML, like Gecko) Version/5.0.2 Mobile/8H7 Safari/6533.18.5': {
         ios: true
       , osversion: '4.3.2'
-      , name: 'iPad'
+      , name: 'Safari'
       , version: '5.0'
       , ipad: true
       , tablet: true
       , webkit: true
       , c: true
+      , safari: true
       }
     , 'Mozilla/5.0 (iPad; U; CPU OS 3_2 like Mac OS X; es-es) AppleWebKit/531.21.10 (KHTML, like Gecko) Version/4.0.4 Mobile/7B360 Safari/531.21.10': {
         ios: true
       , osversion: '3.2'
-      , name: 'iPad'
+      , name: 'Safari'
       , version: '4.0'
       , ipad: true
       , tablet: true
       , webkit: true
       , c: true
+      , safari: true
       }
     }
   , iPod: {
@@ -628,6 +643,8 @@ module.exports.useragents = {
       , mobile: true
       , webkit: true
       , a: true
+      , name: 'Safari'
+      , safari: true
       }
     , 'Mozilla/5.0 (iPod; CPU iPhone OS 5_1 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko) Version/5.1 Mobile/9B176 Safari/7534.48.3': {
         ios: true
@@ -637,6 +654,8 @@ module.exports.useragents = {
       , mobile: true
       , webkit: true
       , c: true
+      , name: 'Safari'
+      , safari: true
       }
     , 'Mozilla/5.0 (iPod; U; CPU iPhone OS 4_3_3 like Mac OS X; en-us) AppleWebKit/533.17.9 (KHTML, like Gecko) Version/5.0.2 Mobile/8J2 Safari/6533.18.5': {
         ios: true
@@ -646,6 +665,8 @@ module.exports.useragents = {
       , mobile: true
       , webkit: true
       , c: true
+      , name: 'Safari'
+      , safari: true
       }
     , 'Mozilla/5.0 (iPod; U; CPU like Mac OS X; en) AppleWebKit/420.1 (KHTML, like Gecko) Version/3.0 Mobile/4A93 Safari/419.3': {
         ios: true
@@ -654,6 +675,8 @@ module.exports.useragents = {
       , mobile: true
       , webkit: true
       , x: true
+      , name: 'Safari'
+      , safari: true
       }
     }
   , BlackBerry: {

--- a/test/test.js
+++ b/test/test.js
@@ -48,7 +48,7 @@ for (g in allUserAgents) { (function(group, userAgents) {
     for (ua in userAgents) { (function(userAgent, expections) {
       describe('user agent "' + userAgent + '"', function() {
 
-        expections.name = group
+        expections.name = expections.name || group
 
         /* Get the result from bowser. */
         var result = browser._detect(userAgent)


### PR DESCRIPTION
Added Safari as the browser name (this is expected) so that it is consistent with the results for other devices.
Updated tests accordingly.