### PR TITLE
fix nexus 7 to 9 considered as a mobile

### DIFF
--- a/src/bowser.js
+++ b/src/bowser.js
@@ -24,6 +24,8 @@
     var iosdevice = getFirstMatch(/(ipod|iphone|ipad)/i).toLowerCase()
       , likeAndroid = /like android/i.test(ua)
       , android = !likeAndroid && /android/i.test(ua)
+      , nexusMobile = /nexus\s*[4-6]\s*/i.test(ua)
+      , nexusTablet = !nexusMobile && /nexus\s*[0-9]+/i.test(ua)
       , chromeos = /CrOS/.test(ua)
       , silk = /silk/i.test(ua)
       , sailfish = /sailfish/i.test(ua)
@@ -242,7 +244,7 @@
 
     // device type extraction
     var osMajorVersion = osVersion.split('.')[0];
-    if (tablet || iosdevice == 'ipad' || (android && (osMajorVersion == 3 || (osMajorVersion == 4 && !mobile))) || result.silk) {
+    if (tablet || nexusTablet || iosdevice == 'ipad' || (android && (osMajorVersion == 3 || (osMajorVersion == 4 && !mobile))) || result.silk) {
       result.tablet = t
     } else if (mobile || iosdevice == 'iphone' || iosdevice == 'ipod' || android || result.blackberry || result.webos || result.bada) {
       result.mobile = t

--- a/src/bowser.js
+++ b/src/bowser.js
@@ -24,7 +24,7 @@
     var iosdevice = getFirstMatch(/(ipod|iphone|ipad)/i).toLowerCase()
       , likeAndroid = /like android/i.test(ua)
       , android = !likeAndroid && /android/i.test(ua)
-      , nexusMobile = /nexus\s*[4-6]\s*/i.test(ua)
+      , nexusMobile = /nexus\s*[0-6]\s*/i.test(ua)
       , nexusTablet = !nexusMobile && /nexus\s*[0-9]+/i.test(ua)
       , chromeos = /CrOS/.test(ua)
       , silk = /silk/i.test(ua)

--- a/src/useragents.js
+++ b/src/useragents.js
@@ -7,7 +7,16 @@
  */
 module.exports.useragents = {
     Chrome: {
-      'Mozilla/5.0 (Linux; Android 4.4.2; Nexus 7 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.99 Safari/537.36': {
+      'Mozilla/5.0 (Linux; Android 5.1.1; Nexus 9 Build/LMY48T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.83 Safari/537.36': {
+        chrome: true
+      , android: true
+      , osversion: '5.1.1'
+      , tablet: true
+      , version: '47.0'
+      , webkit: true
+      , a: true
+      }
+    , 'Mozilla/5.0 (Linux; Android 4.4.2; Nexus 7 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.99 Safari/537.36': {
         chrome: true
       , android: true
       , osversion: '4.4.2'
@@ -884,7 +893,7 @@ module.exports.useragents = {
       , osversion: '4.4.2'
       , webkit: true
       , version: 4.0
-      , mobile: true
+      , tablet: true
       , x: true
       }
     , 'Mozilla/5.0 (Linux; U; Android 4.3; de-de; Galaxy Nexus Build/JWR66Y) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30': {


### PR DESCRIPTION
On nexus 9 for instance we detect the device as a mobile instead of a tablet which cause an error in our UX