### PR TITLE
Fix strict mode logic

### DIFF
--- a/src/bowser.js
+++ b/src/bowser.js
@@ -524,9 +524,7 @@
           if (minVersions.hasOwnProperty(browser)) {
               if (_bowser[browser]) {
                   // browser version and min supported version.
-                  if (compareVersions([version, minVersions[browser]]) < 0) {
-                      return true; // unsupported
-                  }
+                  return compareVersions([version, minVersions[browser]]) < 0;
               }
           }
       }
@@ -540,8 +538,8 @@
    * @param  {Boolean} [strictMode = false] flag to return false if browser wasn't found in map
    * @return {Boolean}
    */
-  function check(minVersions, strictMode) {
-    return !isUnsupportedBrowser(minVersions, strictMode);
+  function check(minVersions, strictMode, ua) {
+    return !isUnsupportedBrowser(minVersions, strictMode, ua);
   }
 
   bowser.isUnsupportedBrowser = isUnsupportedBrowser;

--- a/test/test.js
+++ b/test/test.js
@@ -112,8 +112,18 @@ describe('Unsupported browser check', function() {
     assert.equal(unsupported, false);
   });
 
+  it('should be passed by #isUnsupportedBrowser for IE10.6 and for IE10 miminal version specified in strict mode', function() {
+    var unsupported = browser.isUnsupportedBrowser({msie: "10"}, true, this.ie10_6);
+    assert.equal(unsupported, false);
+  });
+
   it('should NOT be passed by #check for IE10.6 and for IE11 miminal version specified', function() {
     var supported = browser.check({msie: "11"}, this.ie10_6);
+    assert.equal(supported, false);
+  });
+
+  it('should NOT be passed by #check for IE10.6 and for IE11 miminal version specified in strict mode', function() {
+    var supported = browser.check({msie: "11"}, true, this.ie10_6);
     assert.equal(supported, false);
   });
 


### PR DESCRIPTION
As far as I can tell, there is some issue with the logic in `isUnsupportedBrowser`. First red flag is that if `strictMode` is true, then the `isUnsupportedBrowser` will always return true -- there are only two return statements: [the first](https://github.com/nirrattner/bowser/blob/master/src/bowser.js#L528) is always true and the [the second](https://github.com/nirrattner/bowser/blob/master/src/bowser.js#L533) is `strictMode`. Additionally, the tests didn't cover the case where there is a minimum version specified, the version requirement is met, and `strictMode` is true. This test case, which I added here, fails without any of other changes, though it seems to me this case should have the browser pass.