### PR TITLE
fix windowsphone flagged as android

### DIFF
--- a/src/bowser.js
+++ b/src/bowser.js
@@ -321,7 +321,7 @@
     }
 
     // set OS flags for platforms that have multiple browsers
-    if (!result.msedge && (android || result.silk)) {
+    if (!result.windowsphone && !result.msedge && (android || result.silk)) {
       result.android = t
     } else if (iosdevice) {
       result[iosdevice] = t

--- a/src/useragents.js
+++ b/src/useragents.js
@@ -936,6 +936,14 @@ module.exports.useragents = {
       , mobile: true
       , a: true
       }
+    , 'Mozilla/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident/7.0; Touch; rv:11.0; IEMobile/11.0; Microsoft; Lumia 535)': {
+        windowsphone: true
+      , osversion: '8.1'
+      , msie: true
+      , version: '11.0'
+      , mobile: true
+      , a: true
+      }
     }
   , WebOS: {
       'Mozilla/5.0 (hp-tablet; Linux; hpwOS/3.0.5; U; en-US) AppleWebKit/534.6 (KHTML, like Gecko) wOSBrowser/234.83 Safari/534.6 TouchPad/1.0': {


### PR DESCRIPTION
Some User-Agents are flagged as both `windowsphone` and `android` in some situations (example https://github.com/ded/bowser/issues/167).
This PR ensures that we don't add the `android` flag when `windowsphone` is already present.

Closes #167