### PR TITLE
Fix WindowsPhone flagged as iOS

### DIFF
--- a/src/bowser.js
+++ b/src/bowser.js
@@ -323,7 +323,7 @@
     // set OS flags for platforms that have multiple browsers
     if (!result.windowsphone && !result.msedge && (android || result.silk)) {
       result.android = t
-    } else if (iosdevice) {
+    } else if (!result.windowsphone && !result.msedge && iosdevice) {
       result[iosdevice] = t
       result.ios = t
     } else if (mac) {

--- a/src/useragents.js
+++ b/src/useragents.js
@@ -936,8 +936,9 @@ module.exports.useragents = {
       , mobile: true
       , a: true
       }
-    , 'Mozilla/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident/7.0; Touch; rv:11.0; IEMobile/11.0; Microsoft; Lumia 535)': {
+    , 'Mozilla/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident/7.0; Touch; rv:11.0; IEMobile/11.0; Microsoft; Lumia 640 LTE) like iPhone OS 7_0_3 Mac OS X AppleWebKit/537 (KHTML, like Gecko) Mobile Safari/537': {
         windowsphone: true
+      , webkit: true
       , osversion: '8.1'
       , msie: true
       , version: '11.0'


### PR DESCRIPTION
Same issue as in https://github.com/ded/bowser/issues/167 when `like iPhone` is present in the _User Agent_.

Related to !168