### PR TITLE
fix global exports

### DIFF
--- a/src/bowser.js
+++ b/src/bowser.js
@@ -4,11 +4,11 @@
  * MIT License | (c) Dustin Diaz 2015
  */
 
-!function (name, definition) {
+!function (root, name, definition) {
   if (typeof module != 'undefined' && module.exports) module.exports = definition()
   else if (typeof define == 'function' && define.amd) define(name, definition)
-  else this[name] = definition()
-}('bowser', function () {
+  else root[name] = definition()
+}(this, 'bowser', function () {
   /**
     * See useragents.js for examples of navigator.userAgent
     */


### PR DESCRIPTION
Fixes errors like `default.js:19467 Uncaught TypeError: Cannot set property 'bowser' of undefined(…)` when including files like (it's gulp-include):

```js
(function () {
 //= require /path/to/bowser.js
}).call(window);
```